### PR TITLE
add ocaml-for-programming link

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -120,6 +120,9 @@ Issues Noted by Others (Send a PR to add one!)
 7. Create a repository listing useful libraries not yet developed. It could be
    useful for student projects, GSOC or simply inspirations.
 
+8. Tutorials in different languages, other than english. It is always more
+   confortable to learn in his own language.
+
 Optimism
 =========
 

--- a/README.markdown
+++ b/README.markdown
@@ -115,6 +115,8 @@ Issues Noted by Others (Send a PR to add one!)
 
 5. A working OCaml kernel for the Jupyter notebook.
 
+6. Tutorials for beginners from scratch with useful applications as exercices.
+
 Optimism
 =========
 

--- a/README.markdown
+++ b/README.markdown
@@ -61,9 +61,7 @@ to pick OCaml (Some of these issues are being worked on).
 7. A friendlier attitude towards web development. Many people still
    think web coding is lame or not serious. That's wrong, web
    programming is amazing and much innovation comes out of web
-   programming. See [ocaml for web
-   programming](https://github.com/dannywillems/ocaml-for-web-programming) for
-   discussions, todo and tools about web programming in ocaml.
+   programming.
 
 8. Core libs like `Lwt` need love and care, and there are simply not
    enough hands to go around at the moment and that's a real shame

--- a/README.markdown
+++ b/README.markdown
@@ -61,7 +61,9 @@ to pick OCaml (Some of these issues are being worked on).
 7. A friendlier attitude towards web development. Many people still
    think web coding is lame or not serious. That's wrong, web
    programming is amazing and much innovation comes out of web
-   programming.
+   programming. See [ocaml for web
+   programming](https://github.com/dannywillems/ocaml-for-web-programming) for
+   discussions, todo and tools about web programming in ocaml.
 
 8. Core libs like `Lwt` need love and care, and there are simply not
    enough hands to go around at the moment and that's a real shame
@@ -112,7 +114,7 @@ Issues Noted by Others (Send a PR to add one!)
    text encodings in general.
 
 5. A working OCaml kernel for the Jupyter notebook.
- 
+
 Optimism
 =========
 

--- a/README.markdown
+++ b/README.markdown
@@ -117,6 +117,9 @@ Issues Noted by Others (Send a PR to add one!)
 
 6. Tutorials for beginners from scratch with useful applications as exercices.
 
+7. Create a repository listing useful libraries not yet developed. It could be
+   useful for student projects, GSOC or simply inspirations.
+
 Optimism
 =========
 


### PR DESCRIPTION
I created a repository with the same purpose than this manifesto and awesome-ocaml: discuss, listing, develop and reference tools about web programming.

It needs to be improve, hope it could be useful and wll have collaborations. 

I also added some points I think important:
- tutorials from scratch with useful applications: other languages/technologies have success because they provide tutorials with basics examples and exercices give you real applications.
- useful libraries not yet developed: as a student, I was looking for libraries which could have success and could be useful. I would have liked a repository like this to have inspirations. It could be also useful if an hackathon about ocaml is organized (such as for mirageOS).
- tutorials in different languages: other languages/technologies have also success because there are tutorials in a lot of languages. Some doesn't like or can't speak english (or french) and it's hard for them to learn OCaml if there are only tutorials in english or french.
